### PR TITLE
CORS issue of swagger.io resolved

### DIFF
--- a/middleware/404.go
+++ b/middleware/404.go
@@ -16,6 +16,10 @@ func Apply404(h goji.Handler) goji.Handler {
 	return goji.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		handler := middleware.Handler(ctx)
 		if handler == nil {
+			if r.Method == "OPTIONS" {
+				w.WriteHeader(200)
+				return
+			}
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.WriteHeader(404)

--- a/middleware/cross_domain.go
+++ b/middleware/cross_domain.go
@@ -1,0 +1,18 @@
+package middleware
+
+import (
+	"net/http"
+
+	"goji.io"
+	"golang.org/x/net/context"
+)
+
+func CrossDomainRequestAllower(handler goji.Handler) goji.Handler {
+	return goji.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization")
+		//w.Header().Set("Access-Control-Allow-Credentials", "true")
+		handler.ServeHTTPC(ctx, w, r)
+
+	})
+}

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -165,6 +165,7 @@ func SetSubMware(m ...func(goji.Handler) goji.Handler) {
 //and sets the loggers. An application can overwrite the middlewares by calling SetMware & SetSubMware
 func Init(acslog, errlog log.Logger) {
 	SetMware(
+		middleware.CrossDomainRequestAllower,
 		middleware.ApplyReqID,
 		middleware.ApplyLog(acslog),
 		middleware.Apply404,


### PR DESCRIPTION
While sending the request from swagger editor, if there is a custom header then swagger editor send the OPTION request to the same endpoint to get the details of allowed-header.
Bingo's 404 middleware always send 404 response to all not found routes( including previous OPTION request). So the real request will not send.
